### PR TITLE
Add insertion sort to the singly linked list data structure

### DIFF
--- a/problems/linked-list/linked-list.js
+++ b/problems/linked-list/linked-list.js
@@ -135,8 +135,8 @@ SinglyLinkedList.prototype.indexOf = function(value) {
  * @param {Any} initialValue - the initial value to be used in the reduction.
  */
 SinglyLinkedList.prototype.reduce = function(callback, initialValue) {
-    if (this.count <= 1) {
-        return this.head.value;
+    if (this.count < 1) {
+        return initialValue;
     }
 
     // Declare the reducer to apply the callback with to previous and current nodes, accumulating the result.
@@ -152,6 +152,25 @@ SinglyLinkedList.prototype.reduce = function(callback, initialValue) {
     }
 
     return reducer(initialValue || this.head.value, initialValue != null ? this.head : this.head.next);
+}
+
+/**
+ * When called, creates a copy of the linked list and converts it into an array.
+ * @returns {Array} the converted linked list into an array.
+ */
+SinglyLinkedList.prototype.getArrayFromList = function() {
+    return this.reduce((array, value) => {
+        array.push(value);
+        return array;
+    }, []);
+}
+
+/**
+ * Sorts the linked list using the insertion sort algorithm.
+ * @returns {SinglyLinkedList} the sorted linked list.
+ */
+SinglyLinkedList.prototype.insertionSort = function() {
+
 }
 
 module.exports = { SinglyLinkedList, Node };

--- a/problems/linked-list/linked-list.js
+++ b/problems/linked-list/linked-list.js
@@ -166,11 +166,64 @@ SinglyLinkedList.prototype.getArrayFromList = function() {
 }
 
 /**
- * Sorts the linked list using the insertion sort algorithm.
+ * Sorts the singly linked list using the insertion sort algorithm.
  * @returns {SinglyLinkedList} the sorted linked list.
  */
 SinglyLinkedList.prototype.insertionSort = function() {
+     // The head is going to be the first sorted element in the list.
+    let sortedNodesHead = Object.assign({}, this.head);
+    sortedNodesHead.next = null;
 
+    let currentNode = this.head.next;
+    if (currentNode !== null) {
+        do {
+            // Begin traversing and comparing the sorted nodes:
+            // Begin at the first sorted node:
+            let sortedNode = sortedNodesHead;
+            let lastCompared = null;
+            do {
+                // Check if it's equals or greater than the current node:
+                if (currentNode.value <= sortedNode.value) {
+                    // If so, we add it before the sorted node being compared.
+                    const newSortedNode = Object.assign({}, currentNode);
+                    newSortedNode.next = sortedNode;
+
+                    // If the sorted node is the first one, simply set the new head.
+                    if (lastCompared === null) {
+                        sortedNodesHead = newSortedNode;
+                    } else {
+                        // If it's not the first sorted node and there's a last compared one, use it as the previous of the current one.
+                        lastCompared.next = newSortedNode;
+                    }
+
+                    break;
+                }
+
+                // If it's the last node, and the current node isn't smaller than the current sorted one, append it:
+                if (sortedNode.next === null) {
+                    const greatest = Object.assign({}, currentNode);
+                    greatest.next = null;
+
+                    sortedNode.next = greatest;
+
+                    break;
+                }
+                
+                lastCompared = sortedNode;
+                sortedNode = sortedNode.next;
+            } while(sortedNode !== null);
+
+            // Continue to the next one.
+            currentNode = currentNode.next;
+        } while (currentNode !== null);
+    }
+
+    const sortedList = new SinglyLinkedList([]);
+    // TODO: Refactor this:
+    sortedList.head = sortedNodesHead;
+    sortedList.count = 1;
+
+    return sortedList;
 }
 
 module.exports = { SinglyLinkedList, Node };

--- a/problems/linked-list/linked-list.test.js
+++ b/problems/linked-list/linked-list.test.js
@@ -182,6 +182,16 @@ describe('singlyLinkedList.indexOf', () => {
 });
 
 describe('singlyLinkedList.reduce', () => {
+    test('It returns undefined for a list of 0 elements and no initial value', () => {
+        const singlyLinkedList = new SinglyLinkedList([]);
+        expect(singlyLinkedList.reduce((x, y) => x + y)).toBeUndefined();
+    });
+
+    test('It returns the initial value for a list of 0 elements', () => {
+        const singlyLinkedList = new SinglyLinkedList([]);
+        expect(singlyLinkedList.reduce((x, y) => x + y, 2)).toBe(2);
+    });
+
     test('It returns the single list value if the list is of length 1', () => {
         const singlyLinkedList = new SinglyLinkedList([1]);
         expect(singlyLinkedList.reduce((x, y) => x + y)).toBe(1);
@@ -197,3 +207,34 @@ describe('singlyLinkedList.reduce', () => {
         expect(singlyLinkedList.reduce((x, y) => x + y, 5)).toBe(20);
     });
 });
+
+describe('singlyLinkedList.getArrayFromList', () => {
+    test('It returns an empty array for a list of zero elements', () => {
+        const singlyLinkedList = new SinglyLinkedList([]);
+        expect(singlyLinkedList.getArrayFromList()).toEqual([]);
+    });
+
+    test('It returns an array of one element for a list of one element', () => {
+        const singlyLinkedList = new SinglyLinkedList([1]);
+        expect(singlyLinkedList.getArrayFromList()).toEqual([1]);
+    });
+
+    test('It returns an array of n elements for a list of n nodes', () => {
+        const input = [1, 2, 5, 104, 6, 8, 7, 102, 600, 205, 2323];
+        const expectOutput = input;
+
+        const singlyLinkedList = new SinglyLinkedList(input);
+        expect(singlyLinkedList.getArrayFromList()).toEqual(expectOutput);
+    });
+});
+
+// describe('singlyLinkedList.insertionSort', () => {
+//     test('it returns a list of one single node for a linked list of one element', () => {
+//         const singlyLinkedList = new SinglyLinkedList([1]);
+//         expect(singlyLinkedList.insertionSort()).
+//     });
+
+//     test('it sorts a linked list of two nodes', () => {
+
+//     });
+// });

--- a/problems/linked-list/linked-list.test.js
+++ b/problems/linked-list/linked-list.test.js
@@ -228,13 +228,41 @@ describe('singlyLinkedList.getArrayFromList', () => {
     });
 });
 
-// describe('singlyLinkedList.insertionSort', () => {
-//     test('it returns a list of one single node for a linked list of one element', () => {
-//         const singlyLinkedList = new SinglyLinkedList([1]);
-//         expect(singlyLinkedList.insertionSort()).
-//     });
+describe('singlyLinkedList.insertionSort', () => {
+    test('it returns a list of one single node for a linked list of one element', () => {
+        const singlyLinkedList = new SinglyLinkedList([1]);
+        expect(singlyLinkedList.insertionSort().getArrayFromList()).toEqual([1])
+    });
 
-//     test('it sorts a linked list of two nodes', () => {
+    test('it sorts a linked list of two nodes', () => {
+        const singlyLinkedList = new SinglyLinkedList([2, 1]);
+        expect(singlyLinkedList.insertionSort().getArrayFromList()).toEqual([1, 2]);
+    });
 
-//     });
-// });
+    test('it sorts a linked list of four nodes', () => {
+        const singlyLinkedList = new SinglyLinkedList([10, 5, 2, 1]);
+        expect(singlyLinkedList.insertionSort().getArrayFromList()).toEqual([1, 2, 5, 10]);
+    });
+
+    test('it sorts a linked list of 10 nodes', () => {
+        const singlyLinkedList = new SinglyLinkedList([3, 1, 9, 8, 7, 10, 6, 5, 4, 2]);
+        expect(singlyLinkedList.insertionSort().getArrayFromList()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+
+    test('it sorts a linked list with repeated values', () => {
+        const singlyLinkedList = new SinglyLinkedList([3, 1, 9, 8, 7, 10, 7, 6, 8, 5, 4, 2, 1]);
+        expect(singlyLinkedList.insertionSort().getArrayFromList()).toEqual([1, 1, 2, 3, 4, 5, 6, 7, 7, 8, 8, 9, 10]);
+    });
+
+    test('it sorts a linked list of n nodes', () => {
+        const input = [];
+        for (let i = 0; i < 200; i++) {
+            input.push(Math.floor(Math.random() * i));
+        }
+        const expectedOutput = [...input].sort((a, b) => a - b);
+
+        const singlyLinkedList = new SinglyLinkedList(input);
+        
+        expect(singlyLinkedList.insertionSort().getArrayFromList()).toEqual(expectedOutput);
+    });
+});


### PR DESCRIPTION
Adds a new method `insertionSort` to the singly linked list data structure. It returns a new linked list in sorted order.

#### example usage:
`list.insertionSort()`

This is a modified solution to the following LeeCode problem: https://leetcode.com/problems/insertion-sort-list/