### PR TITLE
Add reversed() method to the linked list

### DIFF
--- a/problems/linked-list/linked-list.js
+++ b/problems/linked-list/linked-list.js
@@ -226,4 +226,33 @@ SinglyLinkedList.prototype.insertionSort = function() {
     return sortedList;
 }
 
+/**
+ * Reverses the singly linked list.
+ * @returns {SinglyLinkedList} the reversed linked list.
+ */
+SinglyLinkedList.prototype.reversed = function() {
+    const reversed = new SinglyLinkedList([]);
+
+    let node = Object.assign(new Node(), this.head);
+    let lastTraversedNode = null;
+
+    while(node !== null) {
+        // Save the next node in a constant.
+        const nextTempNode = node.next ? Object.assign(new Node(), node.next) : null;
+
+        // Set the next node of the current to be the last seen one 
+        // (this inverts the order, by chaning the direction). 
+        node.next = lastTraversedNode;
+        lastTraversedNode = node;
+
+        // Set it as the new one.
+        node = nextTempNode;
+    }
+
+    reversed.count = this.count;
+    reversed.head = lastTraversedNode;
+
+    return reversed;
+}
+
 module.exports = { SinglyLinkedList, Node };

--- a/problems/linked-list/linked-list.test.js
+++ b/problems/linked-list/linked-list.test.js
@@ -266,3 +266,30 @@ describe('singlyLinkedList.insertionSort', () => {
         expect(singlyLinkedList.insertionSort().getArrayFromList()).toEqual(expectedOutput);
     });
 });
+
+describe('singlyLinkedList.reverse', () => {
+    test('it returns the reversed empty linked list', () => {
+        const singlyLinkedList = new SinglyLinkedList([]);
+        expect(singlyLinkedList.reversed().getArrayFromList()).toEqual([]);
+    });
+
+    test('it returns the reversed 1->null linked list', () => {
+        const singlyLinkedList = new SinglyLinkedList([1]);
+        expect(singlyLinkedList.reversed().getArrayFromList()).toEqual([1]);
+    });
+
+    test('it returns the reversed 5->1-> linked list', () => {
+        const singlyLinkedList = new SinglyLinkedList([1, 5]);
+        expect(singlyLinkedList.reversed().getArrayFromList()).toEqual([5, 1]);
+    });
+
+    test('it returns the reversed 7->100->1-> linked list', () => {
+        const singlyLinkedList = new SinglyLinkedList([1, 100, 7]);
+        expect(singlyLinkedList.reversed().getArrayFromList()).toEqual([7, 100, 1]);
+    });
+
+    test('it returns the reversed 100->99->98->97->96->95->94->93->92->91->90 linked list', () => {
+        const singlyLinkedList = new SinglyLinkedList([90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100]);
+        expect(singlyLinkedList.reversed().getArrayFromList()).toEqual([100, 99, 98, 97, 96, 95, 94, 93, 92, 91, 90]);
+    });
+});


### PR DESCRIPTION
Adds a `reversed()` method to the linked list, it returns a new linked list with the original nodes in reversed order.

```javascript
const linkedList = new SinglyLinkedList([1, 2, 3]);
console.log(linkedList.reversed().getArrayFromList()); // [3, 2, 1]
```

This is also the solution to the following leet code problem (with a wrapper LinkedList type):
https://leetcode.com/problems/reverse-linked-list/
