### PR TITLE
Add the removeElements method to the SinglyLinkedList

### DIFF
--- a/problems/linked-list/linked-list.js
+++ b/problems/linked-list/linked-list.js
@@ -255,4 +255,34 @@ SinglyLinkedList.prototype.reversed = function() {
     return reversed;
 }
 
+/**
+ * Given a value, removes all nodes that contain it from the linked list.
+ * @param {Any} value - the value to be checked and removed from the linked list.
+ */
+SinglyLinkedList.prototype.removeElements = function(value) {
+    // Get the head of the list.
+    let node = this.head;
+    let last = null;
+
+    // Start traversing the nodes.
+    while(node !== null) {
+        // If the node being traversed has the value to remove:
+        if (node.value === value) {
+            if (node === this.head) {
+                // Simply remove the head.
+                this.head = node.next;
+            } else {
+                // Remove this node by setting the previous.next to be the node to remove.next.
+                last.next = node.next;
+            }
+        } else {
+            last = node;
+        }
+
+        if (node !== null) {
+            node = node.next;
+        }
+    }
+}
+
 module.exports = { SinglyLinkedList, Node };

--- a/problems/linked-list/linked-list.test.js
+++ b/problems/linked-list/linked-list.test.js
@@ -293,3 +293,54 @@ describe('singlyLinkedList.reverse', () => {
         expect(singlyLinkedList.reversed().getArrayFromList()).toEqual([100, 99, 98, 97, 96, 95, 94, 93, 92, 91, 90]);
     });
 });
+
+describe('singlyLinkedList.removeElements', () => {
+    test('it doesn\'t do nothing with an empty list', () => {
+        const singlyLinkedList = new SinglyLinkedList([]);
+        singlyLinkedList.removeElements(1);
+
+        expect(singlyLinkedList.getArrayFromList()).toEqual([]);
+    });
+
+    test('it removes the values of 1 from 1->', () => {
+        const singlyLinkedList = new SinglyLinkedList([1]);
+        singlyLinkedList.removeElements(1);
+
+        expect(singlyLinkedList.getArrayFromList()).toEqual([]);
+    });
+
+    test('it removes the values of 1 from 1->1', () => {
+        const singlyLinkedList = new SinglyLinkedList([1, 1]);
+        singlyLinkedList.removeElements(1);
+
+        expect(singlyLinkedList.getArrayFromList()).toEqual([]);
+    });
+
+    test('it removes the values of 1 from 1->1->2', () => {
+        const singlyLinkedList = new SinglyLinkedList([1, 1, 2]);
+        singlyLinkedList.removeElements(1);
+
+        expect(singlyLinkedList.getArrayFromList()).toEqual([2]);
+    });
+
+    test('it removes the values of 5 from 1->5->2->5->2', () => {
+        const singlyLinkedList = new SinglyLinkedList([1, 5, 2, 5, 2]);
+        singlyLinkedList.removeElements(5);
+
+        expect(singlyLinkedList.getArrayFromList()).toEqual([1, 2, 2]);
+    });
+
+    test('it removes the values of 4 from 4->3->5->10->2->8->4->5->2', () => {
+        const singlyLinkedList = new SinglyLinkedList([4, 3, 5, 10, 2, 8, 4, 5, 2]);
+        singlyLinkedList.removeElements(4);
+
+        expect(singlyLinkedList.getArrayFromList()).toEqual([3, 5, 10, 2, 8, 5, 2]);
+    });
+
+    test('it removes the values of 4 from 1->2->2->1', () => {
+        const singlyLinkedList = new SinglyLinkedList([1, 2, 2, 1]);
+        singlyLinkedList.removeElements(2);
+
+        expect(singlyLinkedList.getArrayFromList()).toEqual([1, 1]);
+    });
+});


### PR DESCRIPTION
The method `removeElements(value)` removes all nodes that have the `value` property equals to the argument one.

#### Example:
```javascript
let list = new SinglyLinkedList([1, 2, 2, 1]);
list.removeElements(2);
console.log(list.getArrayFromList()); // [1, 1]
```

This is a modified solution to the following Leetcode problem: https://leetcode.com/problems/remove-linked-list-elements/